### PR TITLE
fix get icon when blade components are disabled

### DIFF
--- a/src/Tools/Concerns/HasIcon.php
+++ b/src/Tools/Concerns/HasIcon.php
@@ -11,7 +11,8 @@ trait HasIcon
 
     public function getIcon(): string
     {
-        return (string) Str::of(Blade::render('<x-' . $this->icon . ' stroke-width="1.5"/>'))
+        return svg($this->icon)->toHtml();
+        return (string) Str::of(svg($this->icon)->toHtml())
             ->replace("\n", '')
             ->squish();
     }


### PR DESCRIPTION
when blade components are disabled (the default setting for filament)
this will throw the error component not found

I used the `svg` helper but not sure if still needed to replace the `/n`