### PR TITLE
fix: Fix the `make:scribble-tool` static block option key

### DIFF
--- a/src/Commands/MakeToolCommand.php
+++ b/src/Commands/MakeToolCommand.php
@@ -38,7 +38,7 @@ class MakeToolCommand extends Command
                 'command' => 'Command',
                 'event' => 'Event',
                 'modal' => 'Modal',
-                'static' => 'Static Block',
+                'static-block' => 'Static Block',
             ],
             default: 'command',
             required: true,


### PR DESCRIPTION
Fixes an exception thrown when selecting `Static Block` due to a key mismatch between `select()` and the `match` statement for `$type`.