### PR TITLE
breaking: Rename `ScribbleFacade` to `Scribble`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ Manually, creating menu configurations for each instance of the editor can be cu
 ```php
 namespace App\ScribbleProfiles;
 
-use Awcodes\Scribble\Facades\ScribbleFacade;
+use Awcodes\Scribble\Facades\Scribble;
 use Awcodes\Scribble\ScribbleProfile;
 
 class Minimal extends ScribbleProfile
 {
     public static function bubbleTools(): array
     {
-        return ScribbleFacade::getTools([
+        return Scribble::getTools([
             'paragraph',
             'bold',
             'italic',
@@ -142,7 +142,7 @@ class Minimal extends ScribbleProfile
 
     public static function toolbarTools(): array
     {
-        return ScribbleFacade::getTools([
+        return Scribble::getTools([
             'paragraph',
             'bold',
             'italic',
@@ -510,16 +510,15 @@ class Highlight extends ScribbleTool
 Now you can register the tool and PHP parser with the plugin in a ServiceProvider's `register` method.
 
 ```php
-use Awcodes\Scribble\ScribbleManager;
+use Awcodes\Scribble\Facades\Scribble;
 use App\ScribbleTools\Highlight;
 use Tiptap\Marks\Highlight as TiptapHighlight;
 
 public function register(): void
 {
-    app(ScribbleManager::class)
-        ->registerTools([
-            Highlight::make(),
-        ]);
+    Scribble::registerTools([
+        Highlight::make(),
+    ]);
 }
 ```
 

--- a/src/Facades/Scribble.php
+++ b/src/Facades/Scribble.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @see ScribbleManager
  */
-class ScribbleFacade extends Facade
+class Scribble extends Facade
 {
     protected static function getFacadeAccessor(): string
     {

--- a/stubs/profile.stub
+++ b/stubs/profile.stub
@@ -2,28 +2,28 @@
 
 namespace {{ namespace }};
 
-use Awcodes\Scribble\Facades\ScribbleFacade;
+use Awcodes\Scribble\Facades\Scribble;
 use Awcodes\Scribble\ScribbleProfile;
 
 class {{ class_name }} extends ScribbleProfile
 {
     public static function bubbleTools(): array
     {
-        return ScribbleFacade::getTools([
+        return Scribble::getTools([
             //
         ])->toArray();
     }
 
     public static function suggestionTools(): array
     {
-        return ScribbleFacade::getTools([
+        return Scribble::getTools([
             //
         ])->toArray();
     }
 
     public static function toolbarTools(): array
     {
-        return ScribbleFacade::getTools([
+        return Scribble::getTools([
             //
         ])->toArray();
     }


### PR DESCRIPTION
This renames `ScribbleFacade` to `Scribble` and updates usage throughout the project. This is a **breaking change** for anyone using it at the moment.

Removing the `Facade` suffix conforms with Laravel's naming conventions and feels a bit nicer to use while configuring assuming you don't plan on having a potentially conflicting generic `Scribble` class in the future.

Obviously entirely opinionated, feel free to close without explanation.