### PR TITLE
Automatically register tools in the application

### DIFF
--- a/src/ScribbleServiceProvider.php
+++ b/src/ScribbleServiceProvider.php
@@ -57,7 +57,14 @@ class ScribbleServiceProvider extends PackageServiceProvider
     {
         require_once __DIR__ . '/render-helpers.php';
 
-        foreach (app(ScribbleManager::class)->getRegisteredTools() as $tool) {
+        $scribble = app(ScribbleManager::class);
+
+        $scribble->registerToolPath(
+            path: app_path('Scribble/Tools'),
+            namespace: 'App\\Scribble\\Tools'
+        );
+
+        foreach ($scribble->getRegisteredTools() as $tool) {
             if ($tool->getOptionsModal()) {
                 Livewire::component($tool->getIdentifier(), $tool->getOptionsModal());
             }


### PR DESCRIPTION
This adds a `registerToolPath(string $path, string $namespace)` method to `ScribbleManager` to allow registering custom tools in a path and then uses that in the service provider to automatically register tools in the default expected `app_path()` to improve DX.

A future improvement if this PR were to be merged would perhaps be a cache command to cache the registered tool file paths into a manifest.