### PR TITLE
enhance: Improve tool stub generation

### DIFF
--- a/stubs/tool.stub
+++ b/stubs/tool.stub
@@ -5,8 +5,7 @@ namespace {{ namespace }};
 use Awcodes\Scribble\Helpers;
 use Awcodes\Scribble\ScribbleTool;
 use Awcodes\Scribble\Enums\ToolType;
-use {{ namespace }}\Modals\{{ class_name }}Modal;
-use {{ namespace }}\Extensions\{{ class_name }}Extension;
+{{ imports }}
 
 class {{ class_name }} extends ScribbleTool
 {
@@ -16,14 +15,13 @@ class {{ class_name }} extends ScribbleTool
             ->icon(icon: 'heroicon-o-cube-transparent')
             ->label(label: '{{ label }}')
             ->type(type: {{ type }})
-            ->editorView(view: '{{ editor_view }}')
-            ->renderedView(view: '{{ rendered_view }}')
+            {{ views }}
             ->commands([
                  Helpers::makeCommand(command: '', arguments: []),
             ])
             ->optionsModal(component: {{ class_name }}Modal::class)
             ->converterExtensions([
-                new {{ class_name }}Extension()
+                {{ extension }}
             ]);
     }
 }


### PR DESCRIPTION
This improves tool stub generation. Currently the Extension class is always added even when `None` is selected along with a few other inconsistencies. Also made the editor view optional.

### Change log

- enhance: Do not add the converter extension class to generated tools when `None` is selected
- enhance: Add confirmation prompt for optional editor view
- enhance: Improve handling of stub class imports