### PR TITLE
enhance: Make the link ID label translatable

### DIFF
--- a/resources/lang/en/link.php
+++ b/resources/lang/en/link.php
@@ -4,6 +4,7 @@
 return [
     'labels' => [
         'url' => 'URL',
+        'id' => 'ID',
         'language' => 'Language',
         'target' => [
             'default' => 'Default',

--- a/src/Livewire/LinkModal.php
+++ b/src/Livewire/LinkModal.php
@@ -18,7 +18,8 @@ class LinkModal extends ScribbleModal
                         ->columnSpan('full')
                         ->requiredWithout('id')
                         ->validationAttribute('URL'),
-                    Forms\Components\TextInput::make('id'),
+                    Forms\Components\TextInput::make('id')
+                        ->label(trans('scribble::link.labels.id')),
                     Forms\Components\Select::make('target')
                         ->selectablePlaceholder(false)
                         ->options([


### PR DESCRIPTION
This also capitalizes the link ID label for better formatting.